### PR TITLE
Changed Fe from 0.12 to 0.24, K from 0.7 to 0.48, and Cu from 0.002 to 0...

### DIFF
--- a/constants/commercial_products.yml
+++ b/constants/commercial_products.yml
@@ -3,15 +3,15 @@
   # elements = concentration in solution
 ---
 Easy Life ProFito:
-  Fe:     0.12
-  K:      0.7
+  Fe:     0.24
+  K:      0.48
   Mg:     0.09
   dGH:    0.0206606943
-  Mg:     0.09
+  Mg:     
   Mn:     0.04
   I:      0.02
   B:      0.008
-  Cu:     0.002
+  Cu:     0.0002
   Mo:     0.002
   Zn:     0.002
   Li:     0.002


### PR DESCRIPTION
....0002. Left dGH the same and was unsure what to do about the unknown source of the N or the other elements not listed in the guaranteed analysis provided by EasyLife.

ProFito
GUARANTEED ANALYSIS
Total Nitrogen: 0.03% \* Available Phosphate (P2O5): 0% \* Soluble Potash (K2O): 0.58% \* Iron (Fe): 0.24% \* Magnesium (Mg): 0.09% \* Boron (B): 0.008% \* Copper (Cu): 0.0002% \* Manganese (Mn) : 0.04% \* Molybdenum (Mo): 0.002% \* Zinc (Zn) : 0.002%. Derived from Pentetic Acid, Potassium Sulfate, Ferrous Sulfate, Magnesium Chloride, Boric Acid, Copper Sulfate, Manganese Sulfate, Sodium Molybdate, Zinc Sulfate.
