### PR TITLE
Update commercial_products.yml

### DIFF
--- a/constants/commercial_products.yml
+++ b/constants/commercial_products.yml
@@ -159,9 +159,9 @@ Flourish Potassium:
 Flourish Phosphorus:
   K2O:    0.2
   K:      0.166
-  P2O5:   0.2
-  P:      0.0872
-  PO4:    0.267
+  P2O5:   0.3
+  P:      0.1304
+  PO4:    0.4004
   target: PO4
 Flourish Nitrogen:
   N:      1.5


### PR DESCRIPTION
The P2O5 percentage is wrong. It's not 2% it's 3%. So the values for P and PO4 were also wrong as a result. Here are the calculations I used to arrive at the new P and PO4 values. 0.3 / 2.3 = 0.13043478 which is the new P value. The new PO4 value is 0.13043478 (new P value) \* 3.07 = 0.40043478
