### PR TITLE
Update compounds.yml

### DIFF
--- a/constants/compounds.yml
+++ b/constants/compounds.yml
@@ -1,7 +1,7 @@
 # used for constants for input compounds by calc.petalphile.com
 # compound
   # elements = concencentration by mass
-  # tsp = teaspoon concentrations in milligrams
+  # tsp = teaspoon (rounded to 5mL to avoid confusion) concentrations in milligrams
   # sol = maximum solubility in terms of mg/mL
   # target = most useful macro or micronutrient for our users
 ---
@@ -9,40 +9,40 @@ KNO3:
   NO3:    0.6133
   N:      0.138539
   K:      0.3867
-  tsp:    5200
+  tsp:    10545
   sol:    360
   target: NO3
 K2HPO4:
   PO4:    0.545271861
   P:      0.177837745
   K:      0.448963656
-  tsp:    5800
+  tsp:    12200
   sol:    1492
   target: PO4
 KH2PO4:
   PO4:    0.6979
   P:      0.227605
   K:      0.2873
-  tsp:    5600
+  tsp:    11700
   sol:    220
   target: PO4
 K3PO4:
   PO4:    0.447416
   P:      0.145925
   K:      0.552596
-  tsp:    6000
+  tsp:    12800
   sol:    900
   target: PO4
 KCl:
   K:      0.524447
   Cl:     0.18401
-  tsp:    4500
+  tsp:    9900
   sol:    344
   target: K
 K2SO4:
   K:      0.448736
   S:      0.18401
-  tsp:    6400
+  tsp:    13300
   sol:    120
   target: K
 Seachem Equilibrium:


### PR DESCRIPTION
Corrected teaspoon concentrations to accurately reflect the fact that volume = mass/density. That means 1tsp (5mL for simplicity) needs to be multiplied by the density to get grams, then must be multiplied by 1000 for milligrams. Simple stuff.

Prior to these changes, concentrations were off by roughly half which caused the calculator to recommend adding twice as much of each fert as necessary. This would result in vast over-fertilization and probably some serious algae issues.

I'd love to do the rest of the calculations, but I'm unable as I have no idea what the proprietary formulae contain and I don't understand some of the notation (I never was a big chem guy). This at least covers the macros.
