### PR TITLE
Update compounds.yml

### DIFF
--- a/constants/compounds.yml
+++ b/constants/compounds.yml
@@ -143,6 +143,7 @@ Plantex CSM+B:
   B:      0.008
   dGH:    0.00320670391
   tsp:    4300
+  sol:    170
   target: Fe
 Miller's MicroPlex:
   Fe:     0.04


### PR DESCRIPTION
Did a little research on Plantex. Here's the composition link for it, http://msds.plantprod.com/document/1280 Sodium ferric EDTA is the largest component, 53% by my calculations. That's also by far the least soluble of all the ingredients at 90g/L. So the solubility of Plantex will be based on the solubility of the Sodium ferric EDTA. Since it's only 53% by weight we can increase the solubility accordingly to 170g/L.
